### PR TITLE
Agregando un link para el trello del Lab

### DIFF
--- a/_includes/transparency.html
+++ b/_includes/transparency.html
@@ -12,6 +12,13 @@
         <div class="col-md-2 hidden-xs"><img src="img/ico-idea.svg"></div>
         <div class="col-md-10"><div class="h4">La Fundación es un lugar de trabajo que recibe con los brazos abiertos  la innovación, las ideas, los sueños por cambiar las relaciones de poder desde unos a pocos, a muchos.</div></div>
     </div>
+    <div id="en-que-estamos"></div>
+    <h3>¿Qué estamos haciendo justo ahora?</h3>
+    <div class="row rules">
+	<div class="col-md-2 hidden-xs"><i class="fa fa-trello fa-3x"></i></div>
+	<div class="col-md-10"><div class="h4">En <a target="_blank" href="https://trello.com/b/uuZBegM7/lab">este board de Trello</a> puedes ver lo que está haciendo el Lab justo en este momento.</div></div>
+    </div>
+
     <div id="desclasificacion"></div>
     <h3>Desclasificación de la Fundación Ciudadano Inteligente</h3>
     <div class="h4">Revisa nuestra <a href="https://docs.google.com/a/votainteligente.cl/spreadsheets/d/1BRxiP9rUE_Iu_dbrvu7NHWwMSFo53wO7Z6g7meHBH4s/edit#gid=0" target="_blank">agenda de gestión de intereses particulares</a></div>


### PR DESCRIPTION
Debido a que ahora tenemos el Trello del lab abierto pensé que sería buena idea publicarlo en la sección de transparencia de la FCI.

Así se vería la nueva seccion:

![](http://i.imgur.com/Wo7bdPJ.png)